### PR TITLE
Update tables in tool server documentation

### DIFF
--- a/docs/toolbox/servers/data_analytics_servers.md
+++ b/docs/toolbox/servers/data_analytics_servers.md
@@ -10,8 +10,9 @@ This document provides a list of pre-configured MCP servers for Data Analytics t
 *   **Configuration File**: `config/mcp_servers/data_analytics_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `get_steam_trending_games` | Shows currently trending games on Steam with live data |
 | `get_steam_top_sellers` | Displays top-selling games on Steam with real sales data |
 | `get_steam_most_played` | Shows real-time most played games on Steam with current player counts |
@@ -35,8 +36,9 @@ python tests/functional_mcp_client.py '{"name": "game_trends_mcp"}' "Use the 'ge
 *   **Configuration File**: `config/mcp_servers/data_analytics_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `fda_drug_lookup` | Looks up drug information from FDA database |
 | `pubmed_search` | Searches medical literature in PubMed |
 | `health_topics` | Gets evidence-based health information |
@@ -63,8 +65,9 @@ python tests/functional_mcp_client.py '{"name": "healthcare_mcp_public"}' "Use t
 *   **Configuration File**: `config/mcp_servers/data_analytics_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `get_current_weather` | Gets current weather conditions for any US location |
 | `get_weather_forecast` | Provides multi-day weather forecast (up to 7 days) |
 | `get_hourly_forecast` | Shows hour-by-hour weather forecast (up to 48 hours) |
@@ -87,8 +90,9 @@ python tests/functional_mcp_client.py '{"name": "national_weather_service"}' "Us
 *   **Configuration File**: `config/mcp_servers/data_analytics_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `search_pubmed_key_words` | Searches PubMed using keywords |
 | `search_pubmed_advanced` | Performs advanced PubMed search with multiple criteria |
 | `get_pubmed_article_metadata` | Retrieves metadata for a specific PubMed article |
@@ -109,8 +113,9 @@ python tests/functional_mcp_client.py '{"name": "pubmed_mcp_server"}' "Use the '
 *   **Configuration File**: `config/mcp_servers/data_analytics_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `app-store-search` | Search for apps |
 | `app-store-details` | Get detailed app information |
 | `app-store-reviews` | Get app reviews |

--- a/docs/toolbox/servers/example_mcp_servers.md
+++ b/docs/toolbox/servers/example_mcp_servers.md
@@ -10,8 +10,9 @@ This document provides a list of pre-configured MCP servers for example usage th
 *   **Configuration File**: `config/mcp_servers/example_mcp_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `get_weather` | Retrieves the current weather for a specified location. |
 | `get_forecast` | Gets the weather forecast for a specified location for a number of days. |
 
@@ -24,8 +25,9 @@ An agent with access to this server can answer questions like "What's the weathe
 *   **Configuration File**: `config/mcp_servers/example_mcp_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `create_plan` | Creates a new plan with a specified name and steps. |
 | `add_step` | Adds a step to an existing plan. |
 | `get_plan` | Retrieves the details of a specific plan. |

--- a/docs/toolbox/servers/general_purpose_servers.md
+++ b/docs/toolbox/servers/general_purpose_servers.md
@@ -10,8 +10,9 @@ This document provides a list of pre-configured MCP servers for General Purpose 
 *   **Configuration File**: `config/mcp_servers/general_purpose_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `get_config` | Get complete server configuration |
 | `set_config_value` | Set specific configuration values |
 | `read_file` | Read contents of a file or URL |
@@ -46,8 +47,9 @@ python tests/functional_mcp_client.py '{"name": "desktop_commander"}' "list tool
 *   **Configuration File**: `config/mcp_servers/general_purpose_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `initialize_memory_bank` | Initialize a Memory Bank in a specified directory |
 | `set_memory_bank_path` | Set a custom path for the Memory Bank |
 | `debug_mcp_config` | Debug the current MCP configuration |
@@ -79,19 +81,22 @@ python tests/functional_mcp_client.py '{"name": "memory_bank"}' "Use the 'initia
 *   **Configuration File**: `config/mcp_servers/general_purpose_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `save_plan` | Save a plan to disk with optional tags. |
 | `list_plans` | List all available plans, optionally filtered by tag. |
 
 **Prompts:**
+
 | Prompt Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `create_plan_prompt` | Generate a structured planning prompt. |
 
 **Resources:**
+
 | Resource URI | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `planning://plan/{plan_name}` | Get a saved plan as a formatted resource. |
 
 **Example Usage:**

--- a/docs/toolbox/servers/template.md
+++ b/docs/toolbox/servers/template.md
@@ -10,8 +10,9 @@ This document provides a list of pre-configured MCP servers for [Server Category
 *   **Configuration File**: `config/mcp_servers/[filename].json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `[tool_name_1]` | [Description of what the tool does.] |
 | `[tool_name_2]` | [Description of what the tool does.] |
 

--- a/docs/toolbox/servers/web_search_servers.md
+++ b/docs/toolbox/servers/web_search_servers.md
@@ -6,23 +6,25 @@ This document provides a list of pre-configured MCP servers for Web Search that 
 
 ### `duckduckgo_search`
 
-*   **Description**: Enable web search capabilities through DuckDuckGo. Fetch and parse webpage content intelligently for enhanced LLM interaction.
-*   **Configuration File**: `config/mcp_servers/web_search_servers.json`
+* **Description**: Enable web search capabilities through DuckDuckGo. Fetch and parse webpage content intelligently for enhanced LLM interaction.
+* **Configuration File**: `config/mcp_servers/web_search_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `search` | Search DuckDuckGo and return formatted results. **Args:** `query`: The search query string, `max_results`: Maximum number of results to return (default: 10), `ctx`: MCP context for logging |
 | `fetch_content` | Fetch and parse content from a webpage URL. **Args:** `url`: The webpage URL to fetch content from, `ctx`: MCP context for logging |
 
 ### `paper_search`
 
-*   **Description**: Search and download academic papers from multiple sources like arXiv and PubMed. Enhance your research workflow with seamless integration into LLM applications, allowing for efficient access to scholarly content.
-*   **Configuration File**: `config/mcp_servers/web_search_servers.json`
+* **Description**: Search and download academic papers from multiple sources like arXiv and PubMed. Enhance your research workflow with seamless integration into LLM applications, allowing for efficient access to scholarly content.
+* **Configuration File**: `config/mcp_servers/web_search_servers.json`
 
 **Tools:**
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `search_arxiv` | Search academic papers from arXiv. **Args:** `query`: Search query string (e.g., 'machine learning'), `max_results`: Maximum number of papers to return (default: 10) |
 | `search_pubmed` | Search academic papers from PubMed. **Args:** `query`: Search query string, `max_results`: Maximum number of papers to return (default: 10) |
 | `search_biorxiv` | Search academic papers from bioRxiv. **Args:** `query`: Search query string, `max_results`: Maximum number of papers to return (default: 10) |
@@ -31,8 +33,9 @@ This document provides a list of pre-configured MCP servers for Web Search that 
 
 **Excluded**:
 The following tools are excluded as the mcp server does not have file read/write access.
+
 | Tool Name | Description |
-| :-------- | :---------- |
+| --- | --- |
 | `download_arxiv` | Download PDF of an arXiv paper. **Args:** `paper_id`: arXiv paper ID (e.g., '2106.12345'), `save_path`: Directory to save the PDF (default: './downloads') |
 | `download_pubmed` | Attempt to download PDF of a PubMed paper. **Args:** `paper_id`: PubMed ID (PMID), `save_path`: Directory to save the PDF |
 | `download_biorxiv` | Download PDF of a bioRxiv paper. **Args:** `paper_id`: bioRxiv DOI, `save_path`: Directory to save the PDF |


### PR DESCRIPTION
This PR fixes a formatting error present in the tool server docs on the Obsidian [Aurite Documentation](https://publish.obsidian.md/aurite/toolbox/mcp_server_directory) website. 

The lists of tools on the MCP servers are now properly formatted as tables:

![image](https://github.com/user-attachments/assets/51560ecc-f4c2-4f2a-9e9e-49e508f876be)
