### PR TITLE
feat: add OpenAI and Gemini API key placeholders to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ AURITE_ENABLE_DB=false # Set to true to enable DB persistence for configs/histor
 
 ## LLM API Keys
 ANTHROPIC_API_KEY=anthropic_key #REPLACE
+OPENAI_API_KEY=openai_key #REPLACE
+GEMINI_API_KEY=gemini_key #REPLACE
 
 # Aurite Storage DB (Optional Persistence)
 # For the backend service running inside Docker to connect to the postgres Docker service,


### PR DESCRIPTION
Add OPENAI_API_KEY and GEMINI_API_KEY placeholders to the LLM API Keys  section to help new developers understand what environment variables  need to be configured for using OpenAI and Gemini models.

Fixes #33