### PR TITLE
Litellm streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,15 @@ AURITE_ALLOW_DYNAMIC_REGISTRATION=true
 USE_SECRETS_MANAGER=false # Set to true for GCP secrets manager integration
 AURITE_ENABLE_DB=false # Set to true to enable DB persistence for configs/history (requires postgres variables below)
 
+## LLM Gateway
+ENABLE_GATEWAY=true # Set to true if you want to use the LiteLLM Gateway (default true)
+# Disabling the gateway will only allow use of non-streamed Anthropic, OpenAI, and Google models
+
 ## LLM API Keys
 ANTHROPIC_API_KEY=anthropic_key #REPLACE
+OPENAI_API_KEY=openai_key #REPLACE
+GOOGLE_API_KEY=google_key #REPLACE
+# Add any other LiteLLM supported LLM API keys here
 
 # Aurite Storage DB (Optional Persistence)
 # For the backend service running inside Docker to connect to the postgres Docker service,

--- a/aurite_config.json
+++ b/aurite_config.json
@@ -135,6 +135,15 @@
       "auto": false,
       "max_iterations": 5,
       "include_history": false
+    },
+    {
+      "name": "Assistant",
+      "llm_config_id": "openai_gpt4_turbo_mcp",
+      "system_prompt": "You are a helpful assistant",
+      "mcp_servers": [],
+      "auto": false,
+      "max_iterations": 5,
+      "include_history": false
     }
   ],
   "simple_workflows": [

--- a/aurite_config.json
+++ b/aurite_config.json
@@ -56,6 +56,14 @@
       "temperature": 0.1,
       "max_tokens": 4096,
       "default_system_prompt": "You are a helpful assistant."
+    },
+    {
+      "llm_id": "mistral",
+      "provider": "mistral",
+      "model_name": "open-mistral-nemo",
+      "temperature": 0.7,
+      "max_tokens": 2048,
+      "default_system_prompt": "You are a helpful assistant."
     }
   ],
   "agents": [
@@ -130,6 +138,15 @@
     {
       "name": "Gemini Weather Agent",
       "llm_config_id": "gemini-2.5",
+      "system_prompt": "You are a weather assistant. Use the available tools to answer questions about the weather. Respond clearly and concisely. After you receive the weather data, explain it in a simple way.",
+      "mcp_servers": ["weather_server"],
+      "auto": false,
+      "max_iterations": 5,
+      "include_history": false
+    },
+    {
+      "name": "Mistral Weather Agent",
+      "llm_config_id": "mistral",
       "system_prompt": "You are a weather assistant. Use the available tools to answer questions about the weather. Respond clearly and concisely. After you receive the weather data, explain it in a simple way.",
       "mcp_servers": ["weather_server"],
       "auto": false,

--- a/aurite_config.json
+++ b/aurite_config.json
@@ -117,6 +117,24 @@
       "auto": false,
       "max_iterations": 5,
       "include_history": false
+    },
+    {
+      "name": "Anthropic Weather Agent",
+      "llm_config_id": "anthropic_claude_3_opus",
+      "system_prompt": "You are a weather assistant. Use the available tools to answer questions about the weather. Respond clearly and concisely. After you receive the weather data, explain it in a simple way.",
+      "mcp_servers": ["weather_server"],
+      "auto": false,
+      "max_iterations": 5,
+      "include_history": false
+    },
+    {
+      "name": "Gemini Weather Agent",
+      "llm_config_id": "gemini-2.5",
+      "system_prompt": "You are a weather assistant. Use the available tools to answer questions about the weather. Respond clearly and concisely. After you receive the weather data, explain it in a simple way.",
+      "mcp_servers": ["weather_server"],
+      "auto": false,
+      "max_iterations": 5,
+      "include_history": false
     }
   ],
   "simple_workflows": [

--- a/docs/components/llm.md
+++ b/docs/components/llm.md
@@ -38,6 +38,9 @@ An LLM configuration is a JSON object with the following fields:
 | `temperature`           | number | `null`      | The sampling temperature to use for generating responses. Higher values (e.g., 0.8) make output more random, while lower values (e.g., 0.2) make it more deterministic. If `null`, the LLM client's default or the provider's default will be used. |
 | `max_tokens`            | integer| `null`      | The maximum number of tokens to generate in a single response. If `null`, the LLM client's default or the provider's default will be used.                                                                                               |
 | `default_system_prompt` | string | `null`      | A default system prompt that will be used for this LLM configuration if an agent using it doesn't specify its own `system_prompt`.                                                                                                      |
+| `api_base` | string | `null`      | The base URL for the LLM. This will be used by some providers. See https://docs.litellm.ai/docs/providers |
+| `api_key` | string | `null`      | The API key for the LLM. |
+| `api_version` | string | `null`      | The API version for the LLM. |
 | `class Config: extra = "allow"` | N/A    | N/A         | This internal Pydantic setting allows for additional, provider-specific fields to be included in the configuration without causing validation errors. For example, you might add custom parameters required by a specific LLM provider. |
 
 **Note on API Keys and Credentials:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "uvicorn>=0.34.0",
     "fastapi",
     "google-cloud-secret-manager>=2.19.0", # Added for GCP Secrets
+    "litellm>=1.72.6",
 ]
 
 [project.urls]

--- a/src/aurite/bin/api/routes/components_routes.py
+++ b/src/aurite/bin/api/routes/components_routes.py
@@ -127,9 +127,9 @@ async def stream_agent_endpoint(
                 system_prompt=system_prompt,
             ):
                 event_type = event.get(
-                    "event_type", "message"
+                    "type", "message"
                 )  # Default to "message" if no specific type
-                event_data_json = json.dumps(event.get("data", {}))
+                event_data_json = json.dumps(event.get("content", {}))
                 # SSE format:
                 # event: event_name\n
                 # data: json_payload\n

--- a/src/aurite/bin/api/routes/components_routes.py
+++ b/src/aurite/bin/api/routes/components_routes.py
@@ -126,23 +126,12 @@ async def stream_agent_endpoint(
                 user_message=user_message,
                 system_prompt=system_prompt,
             ):
-                event_type = event.get(
-                    "type", "message"
-                )  # Default to "message" if no specific type
-                event_data_json = json.dumps(event.get("content", {}))
-                # SSE format:
-                # event: event_name\n
-                # data: json_payload\n
-                # id: optional_id\n
-                # retry: optional_retry_timeout\n
-                # \n (extra newline to terminate)
-                sse_formatted_event = (
-                    f"event: {event_type}\ndata: {event_data_json}\n\n"
-                )
-                # logger.debug(
-                #     f"SSE Event Yielding: {repr(sse_formatted_event)}"
-                # )  # Log the exact SSE string
-                yield sse_formatted_event
+                if type(event) is dict:
+                    event_string = json.dumps(event)
+                else:
+                    event_string = event.model_dump_json()
+                
+                yield event_string
         except Exception as e:
             logger.error(
                 f"Error during agent streaming for '{agent_name}': {e}", exc_info=True

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -17,7 +17,6 @@ from ...host.host import MCPHost
 # from ..llm.base_client import BaseLLM # Moved to TYPE_CHECKING
 from .agent_models import (
     AgentExecutionResult,
-    AgentOutputContentBlock,
     AgentOutputMessage,
 )
 from .agent_turn_processor import AgentTurnProcessor
@@ -245,9 +244,6 @@ Please correct your previous response to conform to the schema."""
         tools_data = self.host.get_formatted_tools(agent_config=self.config)
         max_iterations = self.config.max_iterations or 10
         current_iteration = 0
-        
-        current_message_content = ""
-        current_message_id = None
         
         while current_iteration < max_iterations:
             current_iteration += 1

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -287,6 +287,21 @@ Please correct your previous response to conform to the schema."""
                         current_message_content += event.get("content", "")
                     elif event_type == "tool_complete":
                         is_tool_turn = True
+                        
+                        message = AgentOutputMessage(
+                            id=current_message_id,
+                            role="assistant",
+                            content=[{
+                                "type": "tool_use",
+                                "id": event["tool_id"],
+                                "name": event["name"],
+                                "input": event["arguments"],
+                            }],
+                            stop_reason="tool_use"
+                        )
+                        
+                        self.conversation_history.append(message)
+                        
                     elif event_type == "tool_result":
                         tool_results.append(event)
                     elif event_type == "message_complete":

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -230,338 +230,117 @@ Please correct your previous response to conform to the schema."""
             )
 
     async def stream_conversation(self) -> AsyncGenerator[Dict[str, Any], None]:
-        logger.info(
-            f"AGENT: Entered stream_conversation for agent '{self.config.name or 'Unnamed'}'"
-        )  # ADDED
-        logger.debug(
-            f"Agent starting STREAMING run for agent '{self.config.name or 'Unnamed'}'."
-        )
-        effective_system_prompt = (
-            self.system_prompt_override
-            or self.config.system_prompt
-            or "You are a helpful assistant."
-        )
+        """
+        Streams the entire conversation with the agent, handling multiple turns
+        and tool executions.
+
+        Yields:
+            Dict[str, Any]: Event dictionaries containing:
+                - type: Event type identifier
+                - data: Event-specific data
+        """
+        logger.info(f"Starting streaming conversation for agent '{self.config.name or 'Unnamed'}'")
+        
+        effective_system_prompt = self.system_prompt_override or self.config.system_prompt or "You are a helpful assistant."
         tools_data = self.host.get_formatted_tools(agent_config=self.config)
         max_iterations = self.config.max_iterations or 10
         current_iteration = 0
-
-        current_assistant_message_content_blocks_for_history_dicts: List[
-            Dict[str, Any]
-        ] = []
-        assistant_message_object_this_turn: Optional[AgentOutputMessage] = None
-
+        
+        current_message_content = ""
+        current_message_id = None
+        
         while current_iteration < max_iterations:
             current_iteration += 1
-            logger.debug(f"Streaming conversation loop iteration {current_iteration}")
-
-            # Create the API-compliant message list for the LLM call in each turn.
-            messages_for_this_llm_call: List[MessageParam] = [
+            logger.debug(f"Starting conversation turn {current_iteration}")
+            
+            # Prepare messages for LLM
+            messages_for_turn = [
                 cast(MessageParam, msg.to_api_message_param())
                 for msg in self.conversation_history
             ]
-
+            
             turn_processor = AgentTurnProcessor(
                 config=self.config,
                 llm_client=self.llm,
                 host_instance=self.host,
-                current_messages=messages_for_this_llm_call,
+                current_messages=messages_for_turn,
                 tools_data=tools_data,
                 effective_system_prompt=effective_system_prompt,
                 llm_config_for_override=self.llm_config_for_override,
             )
-
-            streamed_assistant_message_id: Optional[str] = None
-            streamed_assistant_model: Optional[str] = None
-            streamed_assistant_role: str = "assistant"
-            streamed_assistant_usage: Optional[Dict[str, int]] = None
-            llm_turn_stop_reason: Optional[str] = None
-
-            buffered_tool_results_for_this_turn: List[MessageParam] = []
-
+            
+            # Process the turn
+            is_tool_turn = False
+            tool_results = []
+            
             try:
-                logger.info(
-                    f"AGENT: About to enter turn_processor.stream_turn_response() loop for iteration {current_iteration}"
-                )  # ADDED
                 async for event in turn_processor.stream_turn_response():
+                    # Pass through the event
                     yield event
-                    event_type = event.get("event_type")
-                    event_data = event.get("data", {})
-
+                    
+                    event_type = event["type"]
+                    
+                    # Track message
                     if event_type == "message_start":
-                        streamed_assistant_message_id = event_data.get("message_id")
-                        streamed_assistant_model = event_data.get("model")
-                        streamed_assistant_role = event_data.get("role", "assistant")
-                        current_assistant_message_content_blocks_for_history_dicts = []
-                        assistant_message_object_this_turn = None
-
-                    elif event_type == "text_block_start":
-                        found = False
-                        for (
-                            block
-                        ) in current_assistant_message_content_blocks_for_history_dicts:
-                            if block.get("index") == event_data.get("index"):
-                                found = True
-                                break
-                        if not found:
-                            current_assistant_message_content_blocks_for_history_dicts.append(
-                                {
-                                    "type": "text",
-                                    "text": "",
-                                    "index": event_data.get("index"),
-                                }
-                            )
-                    elif event_type == "text_delta":
-                        found_block = False
-                        for (
-                            block
-                        ) in current_assistant_message_content_blocks_for_history_dicts:
-                            if (
-                                block.get("index") == event_data.get("index")
-                                and block.get("type") == "text"
-                            ):
-                                block["text"] = block.get("text", "") + event_data.get(
-                                    "text_chunk", ""
-                                )
-                                found_block = True
-                                break
-                        if not found_block:
-                            current_assistant_message_content_blocks_for_history_dicts.append(
-                                {
-                                    "type": "text",
-                                    "text": event_data.get("text_chunk", ""),
-                                    "index": event_data.get("index"),
-                                }
-                            )
-                    elif event_type == "thinking_block_start":
-                        found = False
-                        for (
-                            block
-                        ) in current_assistant_message_content_blocks_for_history_dicts:
-                            if block.get("index") == event_data.get("index"):
-                                found = True
-                                break
-                        if not found:
-                            current_assistant_message_content_blocks_for_history_dicts.append(
-                                {
-                                    "type": "text",
-                                    "text": "",
-                                    "index": event_data.get("index"),
-                                }
-                            )
-                    elif event_type == "tool_use_start":
-                        current_assistant_message_content_blocks_for_history_dicts.append(
-                            {
-                                "type": "tool_use",
-                                "id": event_data.get("tool_id"),
-                                "name": event_data.get("tool_name"),
-                                "input": {},
-                                "index": event_data.get("index"),
+                        current_message_id = event.get("message_id")
+                    elif event_type == "content_delta":
+                        current_message_content += event.get("content", "")
+                    elif event_type == "tool_complete":
+                        is_tool_turn = True
+                    elif event_type == "tool_result":
+                        tool_results.append(event)
+                    elif event_type == "message_complete":
+                        # Create and store message in history
+                        message = AgentOutputMessage(
+                            id=current_message_id,
+                            role="assistant",
+                            content=[{
+                                "type": "text",
+                                "text": current_message_content
+                            }],
+                            stop_reason=event.get("stop_reason")
+                        )
+                        self.conversation_history.append(message)
+                        
+                        # Store as final response if not a tool turn
+                        if not is_tool_turn:
+                            self.final_response = message
+                            yield {
+                                "type": "conversation_complete",
+                                "final": True
                             }
+                            return
+
+                # Process tool results if any
+                if tool_results:
+                    for result in tool_results:
+                        tool_message = AgentOutputMessage(
+                            role="user",
+                            content=[{
+                                "type": "tool_result",
+                                "tool_use_id": result["tool_id"],
+                                "content": result["result"] if result["status"] == "success" else result["error"],
+                                "is_error": result["status"] == "error"
+                            }]
                         )
-                    elif event_type == "tool_use_input_complete":
-                        tool_id = event_data.get("tool_id")
-                        final_input = event_data.get("input")
-                        for (
-                            block
-                        ) in current_assistant_message_content_blocks_for_history_dicts:
-                            if (
-                                block.get("type") == "tool_use"
-                                and block.get("id") == tool_id
-                            ):
-                                block["input"] = final_input
-                                break
-
-                    elif (
-                        event_type == "tool_result"
-                        or event_type == "tool_execution_error"
-                    ):
-                        tool_use_id = event_data.get("tool_use_id")
-                        is_error = (
-                            event_type == "tool_execution_error"
-                            or event_data.get("is_error", False)
-                        )
-                        content_data = (
-                            event_data.get("output")
-                            if not is_error
-                            else event_data.get("error_message", "Unknown error")
-                        )
-
-                        tool_result_content_list: List[Dict[str, Any]]
-                        if isinstance(content_data, str):
-                            tool_result_content_list = [
-                                {"type": "text", "text": content_data}
-                            ]
-                        elif isinstance(content_data, list):
-                            tool_result_content_list = content_data
-                        else:
-                            tool_result_content_list = [
-                                {"type": "text", "text": str(content_data)}
-                            ]
-
-                        tool_result_param: MessageParam = cast(
-                            MessageParam,
-                            {
-                                "role": "user",
-                                "content": [
-                                    {
-                                        "type": "tool_result",
-                                        "tool_use_id": tool_use_id,
-                                        "content": tool_result_content_list,
-                                        "is_error": is_error,
-                                    }
-                                ],
-                            },
-                        )
-                        buffered_tool_results_for_this_turn.append(tool_result_param)
-
-                    elif event_type == "message_delta":
-                        if "stop_reason" in event_data:
-                            llm_turn_stop_reason = event_data.get("stop_reason")
-                        if "output_tokens" in event_data:
-                            if streamed_assistant_usage is None:
-                                streamed_assistant_usage = {}
-                            streamed_assistant_usage["output_tokens"] = event_data.get(
-                                "output_tokens"
-                            )
-
-                    elif event_type == "llm_call_completed":
-                        llm_turn_stop_reason = event_data.get("stop_reason")
-                        logger.debug(
-                            f"Agent: LLM call completed with stop_reason: {llm_turn_stop_reason}"
-                        )
-
-                        if streamed_assistant_message_id:
-                            validated_content_blocks_for_model = []
-                            # Use original_llm_content_blocks from the message_stop event if available,
-                            # as it contains the fully formed blocks including tool inputs.
-                            original_llm_content_blocks = (
-                                event_data.get("original_event_data", {})
-                                .get("raw_message_stop_event", {})
-                                .get("message", {})
-                                .get("content", [])
-                            )
-
-                            source_blocks_for_validation = current_assistant_message_content_blocks_for_history_dicts
-                            if (
-                                original_llm_content_blocks
-                            ):  # Prefer original blocks if present
-                                source_blocks_for_validation = (
-                                    original_llm_content_blocks
-                                )
-                                # If using original_llm_content_blocks, ensure they are dicts, not Pydantic models yet
-                                source_blocks_for_validation = [
-                                    block.model_dump(mode="json")
-                                    if hasattr(block, "model_dump")
-                                    else block
-                                    for block in source_blocks_for_validation
-                                ]
-
-                            for block_dict_raw in source_blocks_for_validation:
-                                try:
-                                    # Ensure 'input' is present for tool_use, even if empty, before validation
-                                    # This is crucial if source_blocks_for_validation is from current_assistant_message_content_blocks_for_history_dicts
-                                    if (
-                                        block_dict_raw.get("type") == "tool_use"
-                                        and "input" not in block_dict_raw
-                                    ):
-                                        # Try to find it from tool_use_input_complete if it was missed
-                                        # This part is tricky; ideally, current_assistant_message_content_blocks_for_history_dicts
-                                        # should have the input updated by tool_use_input_complete.
-                                        # If original_llm_content_blocks are used, they should have the input.
-                                        block_dict_raw[
-                                            "input"
-                                        ] = {}  # Default if not found
-
-                                    validated_content_blocks_for_model.append(
-                                        AgentOutputContentBlock.model_validate(
-                                            block_dict_raw
-                                        )
-                                    )
-                                except Exception as e_val:
-                                    logger.error(
-                                        f"Error validating block for AgentOutputMessage: {block_dict_raw}, error: {e_val}"
-                                    )
-                                    validated_content_blocks_for_model.append(
-                                        AgentOutputContentBlock(
-                                            type="error",
-                                            text=f"Invalid block: {str(block_dict_raw)}",
-                                        )
-                                    )
-
-                            assistant_message_object_this_turn = AgentOutputMessage(
-                                id=streamed_assistant_message_id,
-                                model=streamed_assistant_model
-                                or self.config.model
-                                or "unknown_stream_model",
-                                role=streamed_assistant_role,
-                                content=validated_content_blocks_for_model,
-                                stop_reason=llm_turn_stop_reason,
-                                stop_sequence=None,  # Explicitly set to None
-                                usage=streamed_assistant_usage,
-                            )
-                            # The full AgentOutputMessage is the source of truth.
-                            self.conversation_history.append(
-                                assistant_message_object_this_turn
-                            )
-
-                        if buffered_tool_results_for_this_turn:
-                            # Convert tool result dicts to AgentOutputMessage objects
-                            self.conversation_history.extend(
-                                [
-                                    AgentOutputMessage.model_validate(result)
-                                    for result in buffered_tool_results_for_this_turn
-                                ]
-                            )
-                            buffered_tool_results_for_this_turn = []
-
-                        if llm_turn_stop_reason != "tool_use":
-                            logger.debug(
-                                f"Agent: Final response indicated by LLM stop_reason: {llm_turn_stop_reason}. Breaking conversation loop."
-                            )
-                            self.final_response = assistant_message_object_this_turn
-                            break
-                        else:
-                            logger.debug(
-                                "Agent: LLM stop_reason was 'tool_use'. Agent loop continues for next turn."
-                            )
-                            current_assistant_message_content_blocks_for_history_dicts = []
-                            streamed_assistant_message_id = None
-                            streamed_assistant_model = None
-                            streamed_assistant_usage = None
-                            assistant_message_object_this_turn = None
+                        self.conversation_history.append(tool_message)
 
             except Exception as e:
-                error_msg = f"Error during streaming conversation turn {current_iteration}: {type(e).__name__}: {str(e)}"
-                logger.error(error_msg, exc_info=True)
+                logger.error(f"Error in conversation turn {current_iteration}: {e}")
                 yield {
-                    "event_type": "error",
-                    "data": {"message": error_msg, "turn": current_iteration},
+                    "type": "error",
+                    "error": str(e),
+                    "turn": current_iteration
                 }
                 break
 
-            if self.final_response or (
-                llm_turn_stop_reason and llm_turn_stop_reason != "tool_use"
-            ):
-                break
-
+            # Check iteration limit
             if current_iteration >= max_iterations:
-                logger.warning(
-                    f"Reached max iterations ({max_iterations}) in streaming. Aborting."
-                )
-                if not self.final_response and assistant_message_object_this_turn:
-                    self.final_response = assistant_message_object_this_turn
+                logger.warning(f"Reached max iterations ({max_iterations})")
+                yield {
+                    "type": "conversation_complete", 
+                    "reason": "max_iterations"
+                }
                 break
-
-        logger.info(
-            f"Agent finished STREAMING run for agent '{self.config.name or 'Unnamed'}'."
-        )
-        final_stop_reason_for_stream = "unknown"
-        if self.final_response and self.final_response.stop_reason:
-            final_stop_reason_for_stream = self.final_response.stop_reason
-        elif current_iteration >= max_iterations:
-            final_stop_reason_for_stream = "max_iterations_reached"
-
-        yield {
-            "event_type": "stream_end",
-            "data": {"reason": final_stop_reason_for_stream},
-        }
+                
+        logger.info("Conversation streaming completed")

--- a/src/aurite/components/agents/agent_models.py
+++ b/src/aurite/components/agents/agent_models.py
@@ -214,27 +214,3 @@ class AgentExecutionResult(BaseModel):
     def has_error(self) -> bool:
         """Checks if an error message is present."""
         return self.error is not None
-
-
-# --- Agent Input Models ---
-
-class ConversationHistoryMessage(BaseModel):
-    role: str = Field(
-        description="The role of the message sender (e.g., 'user', 'assistant')."
-    )
-    content: str = Field(
-        description="The content of the message"
-    )
-    
-    
-class ToolDefinition(BaseModel):
-    name: str = Field(
-        description="The tool name."
-    )
-    description: str = Field(
-        description="The tool description."
-    )
-    input_schema: dict[str, Any] = Field(
-        description="A json schema describing the input parameters for the tool."
-    )
-    

--- a/src/aurite/components/agents/agent_models.py
+++ b/src/aurite/components/agents/agent_models.py
@@ -3,7 +3,6 @@ Pydantic models for Agent execution inputs and outputs.
 """
 
 from pydantic import BaseModel, Field
-from anthropic.types import MessageParam
 from typing import List, Optional, Dict, Any
 
 # --- Agent Output Models ---

--- a/src/aurite/components/agents/agent_turn_processor.py
+++ b/src/aurite/components/agents/agent_turn_processor.py
@@ -197,7 +197,7 @@ class AgentTurnProcessor:
                 chunk_choice = llm_chunk.get("choices", [{}])[0]
                 delta = chunk_choice.get("delta", {})
                 
-                yield delta
+                yield llm_chunk
                 
                 # Handle message start
                 if delta.get("role") == "assistant" and not current_text_buffer:

--- a/src/aurite/components/agents/agent_turn_processor.py
+++ b/src/aurite/components/agents/agent_turn_processor.py
@@ -177,24 +177,13 @@ class AgentTurnProcessor:
                             Includes text_delta, tool_use_start, tool_use_input_delta,
                             tool_use_end, tool_result, tool_execution_error, stream_end.
         """
-        self._tool_uses_this_turn = []  # Reset for this turn
-
-        # active_tool_calls stores information about tools the LLM has started to use in the current turn.
-        # The key is the LLM's original content_block_index for the tool_use block.
-        active_tool_calls: Dict[int, Dict[str, Any]] = {}
-
-        # SSE Event Indexing Strategy:
-        # The 'index' field in the yielded event_data for events like text_block_start, text_delta,
-        # tool_use_start, tool_use_input_delta, and content_block_stop will directly correspond to
-        # the LLM provider's original content_block.index.
-        # For tool_result and tool_execution_error events, the 'index' will also be the
-        # original content_block.index of the tool_use block that triggered the tool execution.
-        # The frontend primarily uses tool_use_id to associate results with their calls for placement.
-        # This approach simplifies backend logic by removing custom frontend-specific index allocation.
+        self._tool_uses_this_turn = []
+        current_tool_call: Optional[Dict[str, Any]] = None
+        current_text_buffer = ""
 
         try:
             logger.debug("ATP: About to enter LLM stream message loop")  # ADDED
-            async for llm_event in self.llm.stream_message(
+            async for llm_chunk in self.llm.stream_message(
                 messages=self.messages,  # type: ignore[arg-type]
                 tools=self.tools,
                 system_prompt_override=self.system_prompt,
@@ -202,111 +191,69 @@ class AgentTurnProcessor:
                 llm_config_override=self.llm_config_for_override,
             ):
                 logger.debug(
-                    f"ATP: Received LLM event from stream: {llm_event}"
-                )  # ADDED
-                event_type = llm_event.get("event_type")
-                event_data = llm_event.get(
-                    "data", {}
-                ).copy()  # Use a copy for modification
-                llm_event_original_index = event_data.get("index")
+                    f"ATP: Received LLM chunk from stream: {llm_chunk}"
+                ) 
+                chunk_choice = llm_chunk.get("choices", [{}])[0]
+                delta = chunk_choice.get("delta", {})
+                
+                # Handle message start
+                if delta.get("role") == "assistant" and not current_text_buffer:
+                    yield {
+                        "type": "message_start",
+                        "message_id": llm_chunk.get("id"),
+                        "model": llm_chunk.get("model"),
+                    }
+                    
+                # Handle content deltas
+                if content := delta.get("content"):
+                    current_text_buffer += content
+                    yield {
+                        "type": "content_delta",
+                        "content": content
+                    }
+                    
+                # Handle tool calls
+                tool_calls = delta.get("tool_calls", [])
+                if tool_calls:
+                    for tool_call in tool_calls:
+                        # New tool call starting
+                        if tool_call.get("id") and tool_call.get("function", {}).get("name"):
+                            current_tool_call = {
+                                "id": tool_call["id"],
+                                "name": tool_call["function"]["name"],
+                                "arguments": ""
+                            }
+                            yield {
+                                "type": "tool_start",
+                                "tool_id": current_tool_call["id"],
+                                "tool_name": current_tool_call["name"]
+                            }
+                        
+                        # Accumulate tool arguments
+                        if args := tool_call.get("function", {}).get("arguments"):
+                            if current_tool_call:
+                                current_tool_call["arguments"] += args
+                                yield {
+                                    "type": "tool_args_delta",
+                                    "tool_id": current_tool_call["id"],
+                                    "arguments": args
+                                }
 
-                if event_type == "tool_use_start":
-                    if llm_event_original_index is not None:
-                        active_tool_calls[llm_event_original_index] = {
-                            "id": event_data.get("tool_id"),
-                            "name": event_data.get("tool_name"),
-                            "input_str": "",
+                # Handle completion, allow finish_reason to be stop for gemini
+                if chunk_choice.get("finish_reason") in ["tool_calls", "stop"] and current_tool_call:
+                    # Parse and execute tool
+                    try:
+                        tool_args = json.loads(current_tool_call["arguments"])
+                        yield {
+                            "type": "tool_complete",
+                            "tool_id": current_tool_call["id"],
+                            "name": current_tool_call["name"],
+                            "arguments": tool_args
                         }
-                    else:
-                        logger.error(
-                            f"Tool_use_start event is missing 'index'. Cannot track tool call. Data: {event_data}"
-                        )
-                    yield {"event_type": event_type, "data": event_data}
-
-                elif event_type == "tool_use_input_delta":
-                    if (
-                        llm_event_original_index is not None
-                        and llm_event_original_index in active_tool_calls
-                    ):
-                        json_chunk_data = event_data.get("json_chunk")
-                        chunk_to_add = (
-                            str(json_chunk_data) if json_chunk_data is not None else ""
-                        )
-                        active_tool_calls[llm_event_original_index]["input_str"] += (
-                            chunk_to_add
-                        )
-                        # DO NOT YIELD THE tool_use_input_delta EVENT TO THE CLIENT
-                        # logger.debug(f"ATP: Accumulated chunk for tool {active_tool_calls[llm_event_original_index].get('name')}, index {llm_event_original_index}. New input_str: {active_tool_calls[llm_event_original_index]['input_str']}")
-                    else:
-                        logger.warning(
-                            f"ATP: Received tool_use_input_delta for index {llm_event_original_index} but not found in active_tool_calls or index is None."
-                        )
-                    # REMOVED: yield {"event_type": event_type, "data": event_data}
-
-                elif event_type == "content_block_stop":
-                    # We will yield this event, but if it's for a tool, we augment its data first.
-                    # The actual tool execution logic that follows this block remains the same.
-
-                    tool_call_info_for_stop_event = (
-                        None  # Define to avoid UnboundLocalError if conditions not met
-                    )
-                    if (
-                        llm_event_original_index is not None
-                        and llm_event_original_index in active_tool_calls
-                    ):
-                        # This content_block_stop corresponds to an active tool call.
-                        # We will retrieve the info to augment the event_data before yielding.
-                        # The tool_call_info will be popped from active_tool_calls later,
-                        # right before tool execution, as it is now.
-                        tool_call_info_for_stop_event = active_tool_calls[
-                            llm_event_original_index
-                        ]
-
-                        # Augment the event_data for the content_block_stop event
-                        event_data_for_client = (
-                            event_data.copy()
-                        )  # Ensure we modify a copy
-                        event_data_for_client["tool_id"] = (
-                            tool_call_info_for_stop_event.get("id")
-                        )
-                        event_data_for_client["full_tool_input"] = (
-                            tool_call_info_for_stop_event.get("input_str", "")
-                        )
-                        event_data_for_client["content_type"] = (
-                            "tool_use"  # Explicitly mark it for client
-                        )
-
-                        logger.debug(
-                            f"ATP: Yielding augmented content_block_stop for tool_id {event_data_for_client['tool_id']} with full_tool_input."
-                        )
-                        yield {"event_type": event_type, "data": event_data_for_client}
-                    else:
-                        # This content_block_stop is not for an active tool call (e.g., for a text block)
-                        # or the tool call was not properly tracked. Yield as is.
-                        # Add content_type if it's a text block for clarity, if not already present
-                        if (
-                            "content_type" not in event_data
-                        ):  # Check if LLM event already has it
-                            # Infer based on what's NOT in active_tool_calls.
-                            # This might need refinement if LLM sends other block types.
-                            # For now, assume if not a tool, it's text or thinking.
-                            # The LLM event itself might have a more direct indicator.
-                            # Let's assume for now the original event_data is sufficient for non-tool stops.
-                            pass  # Or add event_data["content_type"] = "text"; if needed
-
-                        yield {"event_type": event_type, "data": event_data}
-
-                    # The existing logic for tool execution after content_block_stop:
-                    if (
-                        llm_event_original_index is not None
-                        and llm_event_original_index
-                        in active_tool_calls  # Check again, as it's popped here
-                    ):
-                        # Pop it here, after potentially using its data for the yielded event above
-                        tool_call_info = active_tool_calls.pop(llm_event_original_index)
-                        tool_id = tool_call_info.get("id")
-                        tool_name = tool_call_info.get("name")
-                        tool_input_str = tool_call_info.get("input_str", "")
+                        
+                        tool_id = current_tool_call.get("id")
+                        tool_name = current_tool_call.get("name")
+                        tool_input_str = current_tool_call.get("arguments", "")
                         logger.debug(
                             f"Executing tool '{tool_name}' (ID: {tool_id}) from stream with input: {tool_input_str}"
                         )
@@ -382,30 +329,23 @@ class AgentTurnProcessor:
                                     )
                                     serializable_output = str(tool_result_content)
 
-                                tool_result_data = {
-                                    "index": llm_event_original_index,
-                                    "tool_use_id": tool_id,
-                                    "tool_name": tool_name,
-                                    "status": "success",
-                                    "output": serializable_output,
-                                    "is_error": False,
-                                }
                                 yield {
-                                    "event_type": "tool_result",
-                                    "data": tool_result_data,
+                                    "type": "tool_result",
+                                    "tool_id": current_tool_call["id"],
+                                    "result": serializable_output,
+                                    "status": "success"
                                 }
                             except json.JSONDecodeError as json_err:
                                 logger.error(
                                     f"Failed to parse tool input JSON for tool '{tool_name}': {json_err}"
                                 )
                                 tool_error_data = {
-                                    "index": llm_event_original_index,
                                     "tool_use_id": tool_id,
                                     "tool_name": tool_name,
                                     "error_message": f"Invalid JSON input for tool: {str(json_err)}",
                                 }
                                 yield {
-                                    "event_type": "tool_execution_error",
+                                    "type": "tool_execution_error",
                                     "data": tool_error_data,
                                 }
                             except Exception as e:
@@ -414,13 +354,12 @@ class AgentTurnProcessor:
                                     exc_info=True,
                                 )
                                 tool_error_data = {
-                                    "index": llm_event_original_index,
                                     "tool_use_id": tool_id,
                                     "tool_name": tool_name,
                                     "error_message": str(e),
                                 }
                                 yield {
-                                    "event_type": "tool_execution_error",
+                                    "type": "tool_execution_error",
                                     "data": tool_error_data,
                                 }
                         else:
@@ -428,45 +367,60 @@ class AgentTurnProcessor:
                                 f"Tool name missing for tool use event. Tool ID: {tool_id}"
                             )
                             tool_error_data = {
-                                "index": llm_event_original_index,
                                 "tool_use_id": tool_id,
                                 "tool_name": "unknown_tool",
                                 "error_message": "LLM did not provide a tool name for a tool_use block.",
                             }
                             yield {
-                                "event_type": "tool_execution_error",
+                                "type": "tool_execution_error",
                                 "data": tool_error_data,
                             }
-                    elif (
-                        llm_event_original_index is None
-                        and event_data.get("content_type") == "tool_use"
-                    ):
-                        logger.warning(
-                            f"Content_block_stop for tool_use event missing 'index'. Cannot process tool call. Data: {event_data}"
+                                                
+                        ''' # simple tool calling kept for reference
+                        # Execute tool and get result
+                        result = await self.host.execute_tool(
+                            tool_name=current_tool_call["name"],
+                            arguments=tool_args,
+                            agent_config=self.config
                         )
+                        
+                        # Store tool use
+                        self._tool_uses_this_turn.append({
+                            "id": current_tool_call["id"],
+                            "name": current_tool_call["name"],
+                            "input": tool_args
+                        })
+                        
+                        yield {
+                            "type": "tool_result",
+                            "tool_id": current_tool_call["id"],
+                            "result": result,
+                            "status": "success"
+                        }
+                        
+                        '''
+                    except Exception as e:
+                        yield {
+                            "type": "tool_result",
+                            "tool_id": current_tool_call["id"],
+                            "error": str(e),
+                            "status": "error"
+                        }
+                    current_tool_call = None
 
-                elif event_type == "stream_end":
-                    llm_call_stop_reason = event_data.get("stop_reason")
-                    logger.debug(
-                        f"LLM stream call processing finished by ATP. LLM Stop Reason: {llm_call_stop_reason}"
-                    )
+                # Handle final completion
+                if chunk_choice.get("finish_reason") in ["stop", "length"]:
                     yield {
-                        "event_type": "llm_call_completed",
-                        "data": {
-                            "stop_reason": llm_call_stop_reason,
-                            "original_event_data": event_data,
-                        },
+                        "type": "message_complete",
+                        "content": current_text_buffer,
+                        "stop_reason": chunk_choice.get("finish_reason")
                     }
                     break
 
-                else:  # Handles message_start, text_block_start, text_delta, message_delta, ping, error, unknown
-                    yield {"event_type": event_type, "data": event_data}
-
         except Exception as e:
-            logger.error(f"Error during agent turn streaming: {e}", exc_info=True)
             yield {
-                "event_type": "error",
-                "data": {"message": f"Agent turn processing error: {str(e)}"},
+                "type": "error",
+                "error": str(e)
             }
         finally:
             logger.debug("Finished streaming conversation turn.")

--- a/src/aurite/components/llm/providers/litellm_client.py
+++ b/src/aurite/components/llm/providers/litellm_client.py
@@ -38,9 +38,15 @@ class LiteLLMClient(BaseLLM):
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        api_version: Optional[str] = None,
     ):
         super().__init__(model_name, temperature, max_tokens, system_prompt)
         self.provider = provider
+        self.api_base = api_base
+        self.api_key = api_key
+        self.api_version = api_version
         
         if provider == "gemini":
             # litellm expects GEMINI_API_KEY, however we expect GOOGLE_API_KEY
@@ -194,6 +200,18 @@ class LiteLLMClient(BaseLLM):
         provider_to_use = self.provider
         if llm_config_override and llm_config_override.provider:
             provider_to_use = llm_config_override.provider
+            
+        api_base_to_use = self.api_base
+        if llm_config_override and llm_config_override.api_base:
+            api_base_to_use = llm_config_override.api_base
+        
+        api_key_to_use = self.api_key
+        if llm_config_override and llm_config_override.api_key:
+            api_key_to_use = llm_config_override.api_key
+        
+        api_version_to_use = self.api_version
+        if llm_config_override and llm_config_override.api_version:
+            api_version_to_use = llm_config_override.api_version
 
         temperature_to_use = self.temperature
         if llm_config_override and llm_config_override.temperature is not None:
@@ -234,6 +252,9 @@ class LiteLLMClient(BaseLLM):
             "messages": api_messages,
             "temperature": temperature_to_use,
             "max_tokens": max_tokens_to_use,
+            "api_base": api_base_to_use,
+            "api_key": api_key_to_use,
+            "api_version": api_version_to_use,
         }
 
         if api_tools:

--- a/src/aurite/components/llm/providers/litellm_client.py
+++ b/src/aurite/components/llm/providers/litellm_client.py
@@ -2,6 +2,7 @@
 LLM Client for OpenAI models.
 """
 
+import os
 import logging
 import json  # For parsing tool arguments
 import litellm
@@ -40,6 +41,12 @@ class LiteLLMClient(BaseLLM):
     ):
         super().__init__(model_name, temperature, max_tokens, system_prompt)
         self.provider = provider
+        
+        if provider == "gemini":
+            # litellm expects GEMINI_API_KEY, however we expect GOOGLE_API_KEY
+            # so, we copy it over for the process
+            if 'GEMINI_API_KEY' not in os.environ and 'GOOGLE_API_KEY' in os.environ:
+                os.environ['GEMINI_API_KEY'] = os.environ['GOOGLE_API_KEY']
         logger.info(
             f"LiteLLM initialized for {self.provider}/{self.model_name}."
         )

--- a/src/aurite/components/llm/providers/litellm_client.py
+++ b/src/aurite/components/llm/providers/litellm_client.py
@@ -1,0 +1,394 @@
+"""
+LLM Client for OpenAI models.
+"""
+
+import logging
+import json  # For parsing tool arguments
+import litellm
+from typing import List, Optional, Dict, Any, AsyncGenerator
+
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+)
+from openai.types.chat.chat_completion import Choice
+from pydantic import ValidationError
+
+
+from ..base_client import (
+    BaseLLM,
+    DEFAULT_MAX_TOKENS as BASE_DEFAULT_MAX_TOKENS,
+    DEFAULT_TEMPERATURE as BASE_DEFAULT_TEMPERATURE,
+    # DEFAULT_SYSTEM_PROMPT is also available if needed
+)
+from ...agents.agent_models import AgentOutputMessage, AgentOutputContentBlock
+from ....config.config_models import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMClient(BaseLLM):
+    """LLM Client implementation for LiteLLM."""
+
+    def __init__(
+        self,
+        model_name: str,
+        provider: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        system_prompt: Optional[str] = None,
+    ):
+        super().__init__(model_name, temperature, max_tokens, system_prompt)
+        self.provider = provider
+        logger.info(
+            f"LiteLLM initialized for {self.provider}/{self.model_name}."
+        )
+
+    async def aclose(self):
+        """Closes the underlying httpx client used. Not needed for LiteLLM"""
+        pass
+
+    def _convert_messages_to_openai_format(
+        self, messages: List[Dict[str, Any]], system_prompt: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """Converts Aurite internal message format to OpenAI's expected format."""
+        openai_messages = []
+        if system_prompt:
+            openai_messages.append({"role": "system", "content": system_prompt})
+
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content")
+
+            # Priority 1: Handle Aurite's tool result messages (role="user", content.type="tool_result")
+            # These must be converted to OpenAI's role="tool" messages.
+            if (
+                role == "user"
+                and isinstance(content, list)
+                and content
+                and content[0].get("type") == "tool_result"
+            ):
+                tool_result_block = content[0]
+                tool_output_content = tool_result_block.get("content")
+                tool_output_str = ""
+                if isinstance(tool_output_content, list):  # If list of blocks
+                    text_parts = [
+                        block.get("text", "")
+                        for block in tool_output_content
+                        if block.get("type") == "text"
+                    ]
+                    tool_output_str = "\n".join(text_parts)
+                elif isinstance(tool_output_content, str):
+                    tool_output_str = tool_output_content
+                else:  # Fallback: stringify, OpenAI expects string content for tool role.
+                    try:
+                        tool_output_str = json.dumps(tool_output_content)
+                    except TypeError:  # If not JSON serializable, just stringify
+                        tool_output_str = str(tool_output_content)
+
+                openai_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_result_block.get("tool_use_id"),
+                        "content": tool_output_str,
+                    }
+                )
+            # Priority 2: Handle standard user messages
+            elif role == "user":
+                text_parts = []
+                if isinstance(content, list):
+                    for block in content:  # Should be text blocks
+                        if block.get("type") == "text":
+                            text_parts.append(block.get("text", ""))
+                elif isinstance(content, str):
+                    text_parts.append(content)
+                openai_messages.append(
+                    {"role": "user", "content": " ".join(text_parts)}
+                )
+            # Priority 3: Handle assistant messages
+            elif role == "assistant":
+                assistant_content_parts = []
+                tool_calls_for_api = []
+                if isinstance(content, list):
+                    for block in content:
+                        if block.get("type") == "text":
+                            assistant_content_parts.append(block.get("text", ""))
+                        elif block.get("type") == "tool_use":  # Aurite's tool_use block
+                            tool_calls_for_api.append(
+                                {
+                                    "id": block.get("id"),
+                                    "type": "function",
+                                    "function": {
+                                        "name": block.get("name"),
+                                        "arguments": json.dumps(
+                                            block.get("input", {})
+                                        ),  # OpenAI expects arguments as JSON string
+                                    },
+                                }
+                            )
+
+                assistant_msg_for_api: Dict[str, Any] = {"role": "assistant"}
+                text_content = " ".join(assistant_content_parts).strip()
+                if text_content:
+                    assistant_msg_for_api["content"] = text_content
+                if tool_calls_for_api:
+                    assistant_msg_for_api["tool_calls"] = tool_calls_for_api
+
+                # Add message only if it has content or tool_calls
+                if (
+                    "content" in assistant_msg_for_api
+                    or "tool_calls" in assistant_msg_for_api
+                ):
+                    openai_messages.append(assistant_msg_for_api)
+            else:
+                logger.warning(
+                    f"Unhandled message role for OpenAI conversion: {role} in message: {msg}"
+                )
+        return openai_messages
+
+    def _convert_tools_to_openai_format(
+        self, tools: Optional[List[Dict[str, Any]]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        if not tools:
+            return None
+        openai_tools = []
+        for tool_def in tools:
+            # Assuming Aurite tool format is:
+            # {"name": "tool_name", "description": "...", "input_schema": {...JSONSchema...}}
+            # Convert to OpenAI format:
+            # {"type": "function", "function": {"name": ..., "description": ..., "parameters": ...}}
+            if "name" in tool_def and "input_schema" in tool_def:
+                openai_tools.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": tool_def["name"],
+                            "description": tool_def.get("description", ""),
+                            "parameters": tool_def["input_schema"],
+                        },
+                    }
+                )
+            else:
+                logger.warning(f"Skipping tool with unexpected format: {tool_def}")
+        return openai_tools if openai_tools else None
+
+    async def create_message(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        system_prompt_override: Optional[str] = None,
+        schema: Optional[Dict[str, Any]] = None,  # For JSON mode
+        llm_config_override: Optional[LLMConfig] = None,
+    ) -> AgentOutputMessage:
+        model_to_use = self.model_name
+        if llm_config_override and llm_config_override.model_name:
+            model_to_use = llm_config_override.model_name
+        
+        provider_to_use = self.provider
+        if llm_config_override and llm_config_override.provider:
+            provider_to_use = llm_config_override.provider
+
+        temperature_to_use = self.temperature
+        if llm_config_override and llm_config_override.temperature is not None:
+            temperature_to_use = llm_config_override.temperature
+        elif temperature_to_use is None:  # Ensure a default if not set at all
+            temperature_to_use = BASE_DEFAULT_TEMPERATURE
+
+        max_tokens_to_use = self.max_tokens
+        if llm_config_override and llm_config_override.max_tokens is not None:
+            max_tokens_to_use = llm_config_override.max_tokens
+        elif max_tokens_to_use is None:  # Ensure a default
+            max_tokens_to_use = BASE_DEFAULT_MAX_TOKENS
+
+        resolved_system_prompt = self.system_prompt
+        if llm_config_override and llm_config_override.default_system_prompt:
+            resolved_system_prompt = llm_config_override.default_system_prompt
+        if system_prompt_override is not None:  # Highest precedence
+            resolved_system_prompt = system_prompt_override
+
+        # Convert messages and tools to OpenAI format
+        api_messages = self._convert_messages_to_openai_format(
+            messages, resolved_system_prompt
+        )
+        api_tools = self._convert_tools_to_openai_format(tools)
+
+        request_params: Dict[str, Any] = {
+            "model": f"{provider_to_use}/{model_to_use}",
+            "messages": api_messages,
+            "temperature": temperature_to_use,
+            "max_tokens": max_tokens_to_use,
+        }
+
+        if api_tools:
+            request_params["tools"] = api_tools
+            request_params["tool_choice"] = (
+                "auto"  # Let the model decide if it wants to use tools
+            )
+
+        if schema:  # For JSON mode
+            # Note: Only certain models support JSON mode, so we add to the system prompt
+            json_instruction = f"Your response MUST be a single valid JSON object that conforms to the provided schema. Do NOT add any text or characters before or after, including code block formatting (NO ```) {json.dumps(schema, indent=2)}"
+            if resolved_system_prompt:
+                resolved_system_prompt = (
+                    f"{resolved_system_prompt}\n{json_instruction}"
+                )
+            else:
+                resolved_system_prompt = json_instruction
+
+        logger.debug(
+            f"Making LiteLLM call to '{provider_to_use}/{model_to_use}' with params: {request_params}"
+        )
+
+        try:
+            completion: ChatCompletion = litellm.completion(
+                **request_params
+            )
+        except Exception as e:
+            logger.error(
+                f"LiteLLM API call failed: {type(e).__name__}: {e}", exc_info=True
+            )
+            raise  # Re-raise the original exception
+
+        # Adapt LiteLLM response to AgentOutputMessage
+        choice: Choice = completion.choices[0]
+        message_from_litellm = choice.message
+
+        output_content_blocks: List[AgentOutputContentBlock] = []
+
+        if message_from_litellm.content:  # Text content
+            text_content = str(message_from_litellm.content)
+            if schema and '{' in text_content and '}' in text_content:
+                # trim to curly braces if structured output
+                text_content = text_content[text_content.find('{'): text_content.rfind('}')+1]
+            else:
+                text_content = text_content
+            
+            output_content_blocks.append(
+                AgentOutputContentBlock(
+                    type="text", text=str(message_from_litellm.content)
+                )
+            )
+
+        if message_from_litellm.tool_calls:
+            for tool_call in message_from_litellm.tool_calls:
+                tool_call_data: ChatCompletionMessageToolCall = tool_call
+                try:
+                    arguments = json.loads(tool_call_data.function.arguments)
+                except json.JSONDecodeError:
+                    logger.error(
+                        f"Failed to parse JSON arguments for tool {tool_call_data.function.name}: {tool_call_data.function.arguments}"
+                    )
+                    arguments = {
+                        "error": "failed to parse arguments",
+                        "raw_arguments": tool_call_data.function.arguments,
+                    }
+
+                output_content_blocks.append(
+                    AgentOutputContentBlock(
+                        type="tool_use",
+                        id=tool_call_data.id,
+                        name=tool_call_data.function.name,
+                        input=arguments,
+                    )
+                )
+
+        usage_dict = None
+        if completion.usage:
+            usage_dict = {
+                "input_tokens": completion.usage.prompt_tokens,
+                "output_tokens": completion.usage.completion_tokens,
+            }
+
+        try:
+            agent_output_message = AgentOutputMessage(
+                id=completion.id,
+                model=completion.model,
+                role="assistant",  # OpenAI's response role is always assistant
+                content=output_content_blocks,
+                stop_reason=str(choice.finish_reason) if choice.finish_reason else None,
+                stop_sequence=None,  # OpenAI API doesn't typically return stop_sequence here
+                usage=usage_dict,
+            )
+            return agent_output_message
+        except ValidationError as e:
+            error_msg = f"Failed to validate LiteLLM response against internal AgentOutputMessage model: {e}"
+            logger.error(error_msg, exc_info=True)
+            # Fallback or re-raise
+            raise Exception(error_msg) from e
+
+    async def stream_message(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        system_prompt_override: Optional[str] = None,
+        schema: Optional[Dict[str, Any]] = None,
+        llm_config_override: Optional[LLMConfig] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        logger.warning(
+            "OpenAIClient.stream_message called. This method is not yet fully implemented for robust streaming."
+        )
+        # Basic placeholder for non-streaming call to fulfill generator type hint
+        # For actual streaming, this would involve `await self.client.chat.completions.create(..., stream=True)`
+        # and iterating over the stream, adapting chunks.
+        try:
+            non_streamed_response = await self.create_message(
+                messages, tools, system_prompt_override, schema, llm_config_override
+            )
+            # Simulate a stream for now based on the full response
+            # This is NOT true streaming but makes the test script runnable.
+            yield {
+                "event_type": "message_start",
+                "data": {
+                    "message_id": non_streamed_response.id,
+                    "role": non_streamed_response.role,
+                    "model": non_streamed_response.model,
+                    "input_tokens": non_streamed_response.usage.get("input_tokens")
+                    if non_streamed_response.usage
+                    else 0,
+                },
+            }
+            for i, block in enumerate(non_streamed_response.content):
+                if block.type == "text":
+                    yield {"event_type": "text_block_start", "data": {"index": i}}
+                    if block.text:
+                        yield {
+                            "event_type": "text_delta",
+                            "data": {"index": i, "text_chunk": block.text},
+                        }
+                elif block.type == "tool_use":
+                    yield {
+                        "event_type": "tool_use_start",
+                        "data": {
+                            "index": i,
+                            "tool_id": block.id,
+                            "tool_name": block.name,
+                        },
+                    }
+                    # Simulate input delta if needed, though OpenAI stream gives full input at once
+                    if block.input is not None:
+                        yield {
+                            "event_type": "tool_use_input_delta",  # Or a single "tool_use_input_complete"
+                            "data": {"index": i, "json_chunk": json.dumps(block.input)},
+                        }
+                yield {"event_type": "content_block_stop", "data": {"index": i}}
+
+            yield {
+                "event_type": "message_delta",  # Or directly stream_end if no further deltas
+                "data": {
+                    "stop_reason": non_streamed_response.stop_reason,
+                    "stop_sequence": non_streamed_response.stop_sequence,
+                    "output_tokens": non_streamed_response.usage.get("output_tokens")
+                    if non_streamed_response.usage
+                    else 0,
+                },
+            }
+            yield {
+                "event_type": "stream_end",
+                "data": {"stop_reason": non_streamed_response.stop_reason},
+            }
+
+        except Exception as e:
+            logger.error(
+                f"Error in OpenAIClient.stream_message (simulated): {e}", exc_info=True
+            )
+            yield {"event_type": "error", "data": {"message": str(e)}}

--- a/src/aurite/config/config_models.py
+++ b/src/aurite/config/config_models.py
@@ -212,6 +212,15 @@ class LLMConfig(BaseModel):
     # Provider-specific settings (Example - adjust as needed)
     # api_key_env_var: Optional[str] = Field(None, description="Environment variable name for the API key (if not using default like ANTHROPIC_API_KEY).")
     # credentials_path: Optional[Path] = Field(None, description="Path to credentials file for some providers.")
+    api_base: Optional[str] = Field(
+        default=None, description="The base URL for the LLM."
+    )
+    api_key: Optional[str] = Field(
+        default=None, description="The API key for the LLM."
+    )
+    api_version: Optional[str] = Field(
+        default=None, description="The API version for the LLM."
+    )
 
     class Config:
         extra = "allow"  # Allow provider-specific fields not explicitly defined

--- a/src/aurite/execution/facade.py
+++ b/src/aurite/execution/facade.py
@@ -133,6 +133,9 @@ class ExecutionFacade:
                     temperature=llm_config.temperature,
                     max_tokens=llm_config.max_tokens,
                     system_prompt=llm_config.default_system_prompt,
+                    api_base=llm_config.api_base,
+                    api_key=llm_config.api_key,
+                    api_version=llm_config.api_version,
                 )
             except Exception as e:
                 logger.error(

--- a/src/aurite/execution/facade.py
+++ b/src/aurite/execution/facade.py
@@ -124,7 +124,7 @@ class ExecutionFacade:
             f"Creating LLM client for provider '{provider}', model '{model_name}' (ID: {llm_config.llm_id})"
         )
         
-        if os.getenv("ENABLE_GATEWAY"):
+        if os.getenv("ENABLE_GATEWAY", default=True):
             # Use LiteLLM gateway regardless of provider
             try:
                 return LiteLLMClient(


### PR DESCRIPTION
This PR implements LiteLLM support, including streamed agent responses.
- Any provider/model can now be used when defining an agent as long as it is supported by LiteLLM (see https://docs.litellm.ai/docs/providers), and the corresponding API_KEY is defined in the .env
- Streaming output will follow the LiteLLM format (https://docs.litellm.ai/docs/text_completion). Unstreamed agent calls are unchanged.
- LiteLLM can be disabled in the .env with ```ENABLE_GATEWAY=false```, but this will also disable streaming. The gateway is enabled by default.