### PR TITLE
Add demo config

### DIFF
--- a/.aurite
+++ b/.aurite
@@ -1,3 +1,3 @@
 [aurite]
 type = "workspace"
-projects = ["./src/aurite/init_templates", "./demo_config"]
+projects = ["./src/aurite/init_templates", "./demo-config"]

--- a/.aurite
+++ b/.aurite
@@ -1,3 +1,3 @@
 [aurite]
 type = "workspace"
-projects = ["./src/aurite/init_templates"]
+projects = ["./src/aurite/init_templates", "./demo_config"]

--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,4 @@ notebook-venv/
 docs/guides/
 docs/reports/newman/*
 !src/aurite/init_templates/.env.example
-demo_config/*
+demo-config/*

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ notebook-venv/
 docs/guides/
 docs/reports/newman/*
 !src/aurite/init_templates/.env.example
+demo_config/*


### PR DESCRIPTION
This PR adds the demo-config folder to the `.gitignore` and the workspace `.aurite` as a project.

This change allows users to clone the [demo-config](https://github.com/Aurite-ai/demo-config) repo into aurite-agents to work on components for the demo, without interfering with the aurite-agents repo. 