### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/src/aurite/storage/db_connection.py
+++ b/src/aurite/storage/db_connection.py
@@ -55,7 +55,8 @@ def create_db_engine() -> Optional[Engine]:
         logger.info(f"SQLAlchemy engine created for {engine.url}.")
         return engine
     except Exception as e:
-        logger.error(f"Failed to create SQLAlchemy engine for URL {db_url}: {e}", exc_info=True)
+        sanitized_url = db_url.replace(f":{os.getenv('AURITE_DB_PASSWORD')}@", ":***@") if db_url else "N/A"
+        logger.error(f"Failed to create SQLAlchemy engine for URL {sanitized_url}: {e}", exc_info=True)
         return None
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Aurite-ai/aurite-agents/security/code-scanning/26](https://github.com/Aurite-ai/aurite-agents/security/code-scanning/26)

To resolve the issue, we need to ensure that sensitive information, such as the database password, is not logged. Instead of logging the full database URL (`db_url`), we can redact the password or avoid logging the URL entirely. A safer approach is to log only non-sensitive parts of the URL, such as the database host and name, or use a generic error message that does not include the URL.

Specifically, the fix involves:
1. Updating the error message on line 58 to exclude the full `db_url`. We can redact the password by replacing it with a placeholder (e.g., `***`) or avoid logging the URL altogether.
2. Introducing a helper function to sanitize or redact sensitive information in strings, if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
