### PR TITLE
Nonstreaming agent error handling

### DIFF
--- a/src/aurite/bin/api/routes/facade_routes.py
+++ b/src/aurite/bin/api/routes/facade_routes.py
@@ -134,6 +134,8 @@ async def run_agent(
         status_code = 500
         if type(e) is ConfigurationError:
             status_code = 404
+        elif type(e).__name__ == "AuthenticationError":
+            status_code = 401
         logger.error(f"Error running agent '{agent_name}': {e}")
 
         error_response = {

--- a/src/aurite/bin/api/routes/facade_routes.py
+++ b/src/aurite/bin/api/routes/facade_routes.py
@@ -126,6 +126,9 @@ async def run_agent(
         if result.status == "success":
             return result.model_dump()
 
+        if result.exception:
+            raise result.exception
+
         raise HTTPException(status_code=500, detail=result.error_message)
     except Exception as e:
         status_code = 500

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -138,6 +138,7 @@ class Agent:
                     final_response=None,
                     conversation_history=self.conversation_history,
                     error_message=error_message,
+                    exception=e,
                 )
 
         logger.warning(f"Reached max iterations ({max_iterations}). Aborting loop.")

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -132,7 +132,7 @@ class Agent:
 
             except Exception as e:
                 error_message = f"Error during conversation turn {current_iteration + 1}: {type(e).__name__}: {e}"
-                logger.error(error_message, exc_info=True)
+                logger.error(error_message)
                 return AgentRunResult(
                     status="error",
                     final_response=None,

--- a/src/aurite/components/agents/agent_models.py
+++ b/src/aurite/components/agents/agent_models.py
@@ -24,6 +24,7 @@ class AgentRunResult(BaseModel):
         description="The complete conversation history as a list of dictionaries, compliant with OpenAI's message format."
     )
     error_message: Optional[str] = Field(None, description="An error message if the agent execution failed.")
+    exception: Optional[Any] = Field(None, description="The exception if the agent execution failed.")
 
     @property
     def primary_text(self) -> Optional[str]:


### PR DESCRIPTION
This PR updates error handling for non-streaming agent runs. The format for the error matches that of #82, with an error code of 404 if the agent is not found and 500 for all other errors.