### PR TITLE
Turn limit reached

### DIFF
--- a/src/aurite/bin/api/routes/facade_routes.py
+++ b/src/aurite/bin/api/routes/facade_routes.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from ....components.llm.providers.litellm_client import LiteLLMClient
 from ....config.config_manager import ConfigManager
 from ....config.config_models import AgentConfig, LLMConfig
-from ....errors import ConfigurationError, WorkflowExecutionError
+from ....errors import ConfigurationError, MaxIterationsReachedError, WorkflowExecutionError
 from ....execution.facade import ExecutionFacade
 from ....storage.session_manager import SessionManager
 from ....storage.session_models import ExecutionHistoryResponse, SessionListResponse
@@ -84,6 +84,9 @@ async def run_agent(
                 config_manager.validate_llm(agent_config.llm_config_id)
 
             return result.model_dump()
+
+        elif result.status == "max_iterations_reached":
+            raise MaxIterationsReachedError(detail=result.error_message)
 
         if result.exception:
             raise result.exception

--- a/src/aurite/bin/api/routes/facade_routes.py
+++ b/src/aurite/bin/api/routes/facade_routes.py
@@ -86,7 +86,7 @@ async def run_agent(
             return result.model_dump()
 
         elif result.status == "max_iterations_reached":
-            raise MaxIterationsReachedError(detail=result.error_message)
+            raise MaxIterationsReachedError(result.error_message)
 
         if result.exception:
             raise result.exception

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -257,4 +257,4 @@ class Agent:
                 return
 
         logger.warning(f"Reached max iterations ({max_iterations}) in stream. Ending conversation.")
-        yield {"type": "llm_response_stop", "data": {"status": "warning", "reason": "turn_limit_reached"}}
+        yield {"type": "llm_response_stop", "data": {"status": "error", "reason": "turn_limit_reached"}}

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -234,7 +234,10 @@ class Agent:
                         elif event_type == "message_complete":
                             content = event.get("content", "")
                             self.conversation_history.append({"role": "assistant", "content": content})
-                            yield {"type": "llm_response_stop", "data": {"status": "success", "reason": "success"}}
+                            yield {
+                                "type": "llm_response_stop",
+                                "data": {"status": "success", "reason": "message_complete"},
+                            }
                             if not is_tool_turn:
                                 return  # End of conversation
 

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -97,7 +97,7 @@ class Agent:
                             history, and any errors.
         """
         logger.debug(f"Agent starting run for '{self.config.name or 'Unnamed'}'.")
-        max_iterations = self.config.max_iterations or 10
+        max_iterations = self.config.max_iterations
 
         for current_iteration in range(max_iterations):
             logger.debug(f"Conversation loop iteration {current_iteration + 1}")
@@ -164,7 +164,7 @@ class Agent:
         """
         logger.info(f"Starting streaming conversation for agent '{self.config.name or 'Unnamed'}'")
 
-        max_iterations = self.config.max_iterations or 10
+        max_iterations = self.config.max_iterations
         llm_started = False
 
         for current_iteration in range(max_iterations):

--- a/src/aurite/components/agents/agent.py
+++ b/src/aurite/components/agents/agent.py
@@ -234,7 +234,7 @@ class Agent:
                         elif event_type == "message_complete":
                             content = event.get("content", "")
                             self.conversation_history.append({"role": "assistant", "content": content})
-                            yield {"type": "llm_response_stop", "data": {}}
+                            yield {"type": "llm_response_stop", "data": {"status": "success", "reason": "success"}}
                             if not is_tool_turn:
                                 return  # End of conversation
 
@@ -254,3 +254,4 @@ class Agent:
                 return
 
         logger.warning(f"Reached max iterations ({max_iterations}) in stream. Ending conversation.")
+        yield {"type": "llm_response_stop", "data": {"status": "warning", "reason": "turn_limit_reached"}}

--- a/src/aurite/config/config_models.py
+++ b/src/aurite/config/config_models.py
@@ -224,7 +224,7 @@ class AgentConfig(BaseComponentConfig):
         description="JSON schema for validating agent-specific configurations.",
     )
     # --- Agent Behavior ---
-    max_iterations: Optional[int] = Field(default=None, description="Max conversation turns before stopping.")
+    max_iterations: Optional[int] = Field(default=10, description="Max conversation turns before stopping.")
     include_history: Optional[bool] = Field(
         default=None,
         description="Whether to include the conversation history, or just the latest message.",

--- a/src/aurite/config/config_models.py
+++ b/src/aurite/config/config_models.py
@@ -224,7 +224,7 @@ class AgentConfig(BaseComponentConfig):
         description="JSON schema for validating agent-specific configurations.",
     )
     # --- Agent Behavior ---
-    max_iterations: Optional[int] = Field(default=10, description="Max conversation turns before stopping.")
+    max_iterations: Optional[int] = Field(default=50, description="Max conversation turns before stopping.")
     include_history: Optional[bool] = Field(
         default=None,
         description="Whether to include the conversation history, or just the latest message.",

--- a/src/aurite/errors.py
+++ b/src/aurite/errors.py
@@ -61,3 +61,11 @@ class MCPServerTimeoutError(MCPHostError):
         self.timeout_seconds = timeout_seconds
         self.operation = operation
         super().__init__(f"MCP server '{server_name}' {operation} timed out after {timeout_seconds} seconds")
+
+
+class MaxIterationsReachedError(AuriteError):
+    """
+    Raised when the max turn limit is reached during agent execution.
+    """
+
+    pass


### PR DESCRIPTION
This PR edits the behavior of the agent streaming endpoint to send a final chunk when the turn limit is reached to signal the end of the stream. This solves an issue of the conversation hanging on the frontend, as the stream is never properly closed. This will have the following format:
```
{
    "type": "llm_response_stop",
    "data": {
        "status": "error", 
        "reason": "turn_limit_reached"
    }
}
```
The normal llm_response_stop has also been edited to contain a status and reason in the data:
```
{
    "type": "llm_response_stop",
    "data": {
        "status": "success", 
        "reason": "message_complete"
    }
}
```

The non-streamed turn limit behavior has also been edited to return a more detailed error message. This will be with a 500 response code. Below is an example:
```
{
    "error": {
        "message": "Agent stopped after reaching the maximum of 2 iterations.",
        "error_type": "MaxIterationsReachedError",
        "details": {
            "agent_name": "Test Turns Weather Agent",
            "user_message": "london",
            "system_prompt": null,
            "session_id": null
        }
    }
}
```