### PR TITLE
change llm.api_key to api_key_env_var

### DIFF
--- a/docs/config/llm.md
+++ b/docs/config/llm.md
@@ -70,9 +70,9 @@ These fields are used for connecting to specific APIs, especially for self-hoste
 **Type:** `string` (Optional)
 **Description:** The base URL for the API endpoint. This is commonly used for local models (e.g., `http://localhost:8000/v1`) or custom provider endpoints.
 
-### `api_key`
+### `api_key_env_var`
 **Type:** `string` (Optional)
-**Description:** The API key for the provider. It is **highly recommended** to manage API keys using environment variables instead of placing them directly in configuration files. However, this field is available for convenience or specific use cases.
+**Description:** The environment variable name for the API key to use with this LLM (if not using default like ANTHROPIC_API_KEY)
 
 ### `api_version`
 **Type:** `string` (Optional)

--- a/src/aurite/components/llm/providers/litellm_client.py
+++ b/src/aurite/components/llm/providers/litellm_client.py
@@ -106,13 +106,17 @@ class LiteLLMClient:
         api_messages = self._convert_messages_to_openai_format(messages, resolved_system_prompt)
         api_tools = self._convert_tools_to_openai_format(tools)
 
+        api_key = None
+        if self.config.api_key_env_var:
+            api_key = os.getenv(self.config.api_key_env_var)
+
         request_params: Dict[str, Any] = {
             "model": f"{self.config.provider}/{self.config.model}",
             "messages": api_messages,
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
             "api_base": self.config.api_base,
-            "api_key": self.config.api_key,
+            "api_key": api_key,
             "api_version": self.config.api_version,
         }
 

--- a/src/aurite/config/config_models.py
+++ b/src/aurite/config/config_models.py
@@ -163,10 +163,12 @@ class LLMConfig(BaseComponentConfig):
     )
 
     # Provider-specific settings (Example - adjust as needed)
-    # api_key_env_var: Optional[str] = Field(None, description="Environment variable name for the API key (if not using default like ANTHROPIC_API_KEY).")
+    api_key_env_var: Optional[str] = Field(
+        None, description="Environment variable name for the API key (if not using default like ANTHROPIC_API_KEY)."
+    )
     # credentials_path: Optional[Path] = Field(None, description="Path to credentials file for some providers.")
     api_base: Optional[str] = Field(default=None, description="The base URL for the LLM.")
-    api_key: Optional[str] = Field(default=None, description="The API key for the LLM.")
+    # api_key: Optional[str] = Field(default=None, description="The API key for the LLM.")
     api_version: Optional[str] = Field(default=None, description="The API version for the LLM.")
 
     class Config:


### PR DESCRIPTION
This PR changes the previous llm config param `api_key` to `api_key_env_var`. This optional parameter can be set to the name of an environment variable to use that as the API key for the LLM call, rather than the default for provider. 