### PR TITLE
List components invalid type

### DIFF
--- a/src/aurite/bin/api/routes/config_routes.py
+++ b/src/aurite/bin/api/routes/config_routes.py
@@ -68,6 +68,14 @@ async def list_components_by_type(
     _refresh_config_if_needed(config_manager)
     # Convert plural to singular if needed
     singular_type = PLURAL_TO_SINGULAR.get(component_type, component_type)
+
+    valid_types = list(config_manager.get_all_configs().keys())
+    if singular_type not in valid_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid component type '{component_type}'. Valid types are: {', '.join(valid_types)}",
+        )
+
     return config_manager.list_configs(singular_type)
 
 

--- a/tests/fixtures/workspace/shared_configs/history_test_workflows.json
+++ b/tests/fixtures/workspace/shared_configs/history_test_workflows.json
@@ -111,7 +111,7 @@
     "include_history": false
   },
   {
-    "type": "simple_workflow",
+    "type": "linear_workflow",
     "steps": [
       "History Test Agent A1",
       "History Test Agent A2"


### PR DESCRIPTION
This PR adds an check in the list components endpoint to first check if the component type is valid. If it is invalid, it returns 400, unlike the previous behavior of empty list with 200.