### PR TITLE
Config validation

### DIFF
--- a/src/aurite/bin/api/routes/config_routes.py
+++ b/src/aurite/bin/api/routes/config_routes.py
@@ -215,6 +215,13 @@ async def update_component(
     full_config = component_data.config.copy()
     full_config["name"] = component_id
 
+    is_valid, validation_errors = config_manager._validate_component_config(singular_type, full_config)
+    if not is_valid:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Component configuration validation failed: {'; '.join(validation_errors)}",
+        )
+
     # Use the existing update_component method
     success = config_manager.update_component(singular_type, component_id, full_config)
 

--- a/src/aurite/lib/config/config_manager.py
+++ b/src/aurite/lib/config/config_manager.py
@@ -214,7 +214,7 @@ class ConfigManager:
             valid, errors = self._validate_component_config(component_type=component_type, config=component_data)
             if not valid:
                 logger.warning(
-                    f"Skipping component {component_id} in {config_file} due to invalid config. Errors: {', '.join(errors)}"
+                    f"Skipping component '{component_id}' in {config_file} due to invalid config: {'; '.join(errors)}"
                 )
                 continue
 

--- a/src/aurite/lib/config/config_manager.py
+++ b/src/aurite/lib/config/config_manager.py
@@ -211,6 +211,13 @@ class ConfigManager:
                 logger.warning(f"Skipping component in {config_file} due to missing 'type' or 'name'.")
                 continue
 
+            valid, errors = self._validate_component_config(component_type=component_type, config=component_data)
+            if not valid:
+                logger.warning(
+                    f"Skipping component {component_id} in {config_file} due to invalid config. Errors: {', '.join(errors)}"
+                )
+                continue
+
             self._component_index.setdefault(component_type, {})
 
             # Honor the priority of sources: if a component is already indexed, skip
@@ -716,7 +723,13 @@ class ConfigManager:
             A tuple containing a boolean indicating if the component is valid,
             and a list of validation error messages.
         """
-        from ..models.config.components import AgentConfig, ClientConfig, CustomWorkflowConfig, LLMConfig, WorkflowConfig
+        from ..models.config.components import (
+            AgentConfig,
+            ClientConfig,
+            CustomWorkflowConfig,
+            LLMConfig,
+            WorkflowConfig,
+        )
 
         # Map component types to their Pydantic models
         model_map = {


### PR DESCRIPTION
This PR adds config validation for components on API startup and when components are updated. If a component is invalid, it is skipped and a warning message is logged.