### PR TITLE
fix agent system prompt override

### DIFF
--- a/src/aurite/execution/aurite_engine.py
+++ b/src/aurite/execution/aurite_engine.py
@@ -26,7 +26,6 @@ from ..lib.models.config.components import (
     ClientConfig,
     CustomWorkflowConfig,
     LLMConfig,
-    LLMConfigOverrides,
     WorkflowConfig,
 )
 
@@ -181,9 +180,7 @@ class AuriteEngine:
             )
 
         if system_prompt_override:
-            if agent_config_for_run.llm is None:
-                agent_config_for_run.llm = LLMConfigOverrides()
-            agent_config_for_run.llm.system_prompt = system_prompt_override
+            agent_config_for_run.system_prompt = system_prompt_override
 
         agent_instance = Agent(
             agent_config=agent_config_for_run,


### PR DESCRIPTION
This PR fixes the behavior of the system prompt override for agents. Previously, the system prompt override was being used to overwrite the llm's default system prompt. As llm default is lower priority, the agent's system prompt would not actually be overwritten. This change fixes it to actually overwrite the agent's system prompt.