### PR TITLE
Fix API compatibility issues in run_example_project.py template

### DIFF
--- a/src/aurite/lib/init_templates/run_example_project.py
+++ b/src/aurite/lib/init_templates/run_example_project.py
@@ -25,7 +25,8 @@ async def main():
     aurite = Aurite()
 
     try:
-        await aurite.initialize()
+        # Properly initialize the kernel
+        await aurite.kernel.initialize()
 
         # --- Dynamic Registration Example ---
         # The following section demonstrates how to dynamically register components
@@ -39,7 +40,7 @@ async def main():
             model="gpt-4-turbo-preview",
         )
 
-        await aurite.register_llm_config(llm_config)
+        await aurite.register_llm(llm_config)
 
         # # 2. Define and register an MCP server configuration
         # mcp_server_config = ClientConfig(
@@ -74,8 +75,14 @@ async def main():
 
     except Exception as e:
         logger.error(f"An error occurred during agent execution: {e}", exc_info=True)
-        await aurite.shutdown()
-        logger.info("Aurite shutdown complete.")
+    
+    finally:
+        # Properly shutdown the kernel
+        try:
+            await aurite.kernel.shutdown()
+            logger.info("Aurite shutdown complete.")
+        except Exception as shutdown_error:
+            logger.error(f"Error during shutdown: {shutdown_error}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  Description:
  ## Problem
  The `run_example_project.py` template generated by `aurite init` contains several
  API compatibility issues that cause AttributeError exceptions when users try to
  run the example:

  1. `await aurite.initialize()` - method doesn't exist on Aurite class
  2. `await aurite.register_llm_config(llm_config)` - method should be
  `register_llm()`
  3. `await aurite.shutdown()` - method doesn't exist on Aurite class
  4. Missing proper async resource cleanup

  ## Solution
  - Replace `aurite.initialize()` with `aurite.kernel.initialize()`
  - Fix method name from `register_llm_config()` to `register_llm()`
  - Replace `aurite.shutdown()` with proper `aurite.kernel.shutdown()` in finally
  block
  - Add proper async resource cleanup and error handling

  ## Testing
  - [x] Template now runs without AttributeError exceptions
  - [x] Proper kernel initialization and shutdown
  - [x] Agent successfully executes weather query example
  - [x] Clean async resource cleanup (no task cancellation errors)

  ## Impact
  This fixes the first-run experience for new Aurite users who follow the getting
  started guide.