### PR TITLE
fix: add git synchronization to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,6 +156,11 @@ jobs:
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             
+            # Sync with remote to get latest changes from changelog workflow
+            echo "Fetching latest changes from remote..."
+            git fetch origin
+            git pull origin main --rebase
+            
             # Clean dist directory from test build
             rm -rf dist/
             


### PR DESCRIPTION
- Add git fetch and pull commands before version bump in production releases
- Prevents git push conflicts when changelog workflow updates repository first
- Ensures release workflow has latest changes before attempting to push version bump